### PR TITLE
Added extra parameter to setFormat in example code

### DIFF
--- a/src/Turbo/Resources/doc/index.rst
+++ b/src/Turbo/Resources/doc/index.rst
@@ -327,7 +327,7 @@ Let's discover how to use Turbo Streams to enhance your `Symfony forms`_::
                 // 🔥 The magic happens here! 🔥
                 if (TurboBundle::STREAM_FORMAT === $request->getPreferredFormat()) {
                     // If the request comes from Turbo, set the content type as text/vnd.turbo-stream.html and only send the HTML to update
-                    $request->setFormat(TurboBundle::STREAM_FORMAT);
+                    $request->setFormat(TurboBundle::STREAM_FORMAT, TurboBundle::STREAM_MEDIA_TYPE);
                     return $this->render('task/success.stream.html.twig', ['task' => $task]);
                 }
 


### PR DESCRIPTION
This is just an update to the documentation.

I copied the example code in my project, but I got an error on
```
 $request->setFormat(TurboBundle::STREAM_FORMAT);
```

The setFormat-function seems to expect 2 parameters. When I did
```
 $request->setFormat(TurboBundle::STREAM_FORMAT, TurboBundle::STREAM_MEDIA_TYPE);
```

It worked like a charm :-) (on the bleading edge; this doesn't seem to be available in ux-turbo 2.0.1 yet.)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
